### PR TITLE
Avoid 'uninitialized constant LeanTesting::OAuth2Handler::Curl'

### DIFF
--- a/leantesting.gemspec
+++ b/leantesting.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
 	s.name        = 'leantesting'
-	s.version     = '1.2.0'
+	s.version     = '1.2.1'
 	s.date        = '2016-04-12'
 	s.platform    = Gem::Platform::RUBY
 	s.summary     = 'Lean Testing Ruby SDK'

--- a/lib/BaseClass/EntityHandler.rb
+++ b/lib/BaseClass/EntityHandler.rb
@@ -76,8 +76,8 @@ module LeanTesting
 		#	SDKInvalidArgException if provided id param is not an integer.
 		#
 		def find(id)
-			if !id.is_a? Fixnum
-				raise SDKInvalidArgException, '`id` must be of type Fixnum'
+			if !id.is_a? Integer
+				raise SDKInvalidArgException, '`id` must be of type Integer'
 			end
 		end
 


### PR DESCRIPTION
I load the gem `curb` in the autoloader to be able to create auth link without errors.
Fixes #4 
